### PR TITLE
Creating the recipes menu template

### DIFF
--- a/tasties/urls.py
+++ b/tasties/urls.py
@@ -20,5 +20,6 @@ from tasties_app import views
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', views.index, name="index"),
-    path('base/', views.base, name="base")
+    path('base/', views.base, name="base"),
+    path('recipes/', views.recipes, name="recipes")
 ]

--- a/tasties_app/static/css/recipes.css
+++ b/tasties_app/static/css/recipes.css
@@ -1,0 +1,53 @@
+.row{
+    display: flex;
+    justify-content: center;
+    margin: 50px;
+}
+
+.row a{
+    text-decoration: none;
+    color: #000;
+}
+
+.card{
+    margin-bottom: 30px;
+    width: 18rem;
+    height: 400px;
+}
+
+.card:hover{
+    box-shadow: 0 0 4px 0 rgba(0,0,0,0.2), 0 0 10px 0 rgba(0,0,0,0.19);
+}
+
+.card-title{
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    font-size: 18px;
+    height: 25px;
+}
+
+.card-text{
+    height: 72px;
+}
+
+.text-truncate-container{
+    width: 250px;
+    -webkit-line-clamp: 3;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.card-img-top{
+    border-radius: 3px;
+    max-height: 190.66px;
+    object-fit: fill;
+}
+
+.card-footer{
+    background-color: white;
+    display: flex;
+    justify-content: space-between;
+    padding: 10px 0 0 0;
+}

--- a/tasties_app/templates/tasties_app/recipes.html
+++ b/tasties_app/templates/tasties_app/recipes.html
@@ -1,0 +1,36 @@
+{% extends 'tasties_app/base.html' %}
+{% load static %}
+{% block css %}
+    {% load bootstrap_icons %}
+    <link rel="stylesheet" type="text/css" href="{% static 'css/recipes.css' %}" />
+{% endblock %}
+{% block content %}
+    <div class="grid">
+    <div class="row">
+    {% for recipe, rating in recipes_with_ratings.items %}
+      <div class="col-sm-6 col-md-6 col-lg-4 col-xl-3">
+        <a href="#">
+            <div class="card">
+              <img
+                class="card-img-top"
+                src="{% static recipe.recipe_picture %}"
+                alt="{{ recipe.title }}"
+              />
+
+              <div class="card-body">
+                <h2 class="card-title">{{ recipe.title }}</h2>
+                <p class="card-text text-truncate-container">
+                  {{ recipe.description }}
+                </p>
+                <div class="card-footer">
+                  <span class="minutes">{% bs_icon 'clock-history' %} {{ recipe.minutes_to_make }} mins</span>
+                  <span class="rating">{% bs_icon 'star-fill' %} {{ rating | floatformat:2 }}</span>
+                </div>
+              </div>
+            </div>
+        </a>
+      </div>
+    {% endfor %}
+    </div>
+    </div>
+{% endblock %}

--- a/tasties_app/tests/test_recipes_view.py
+++ b/tasties_app/tests/test_recipes_view.py
@@ -1,0 +1,10 @@
+import pytest
+from pytest_django.asserts import assertTemplateUsed
+
+
+@pytest.mark.django_db
+class TestRecipesView:
+    def test_recipes_view(self, client):
+        response = client.get('/recipes/')
+        assert response.status_code == 200
+        assertTemplateUsed(response, 'tasties_app/recipes.html')

--- a/tasties_app/views.py
+++ b/tasties_app/views.py
@@ -1,4 +1,7 @@
 from django.shortcuts import render
+from tasties_app.models import Recipe, Rating
+from django.db.models import Avg
+from collections import OrderedDict
 
 
 def index(request):
@@ -7,3 +10,13 @@ def index(request):
 
 def base(request):
     return render(request, 'tasties_app/base.html',)
+
+
+def recipes(request):
+    recipes_list = Recipe.objects.all()
+    recipes_with_ratings = {}
+    for recipe in recipes_list:
+        recipes_with_ratings[recipe] = Rating.objects.filter(recipe_id=recipe).aggregate(Avg('rating'))['rating__avg']
+    recipes_with_ratings = OrderedDict(sorted(recipes_with_ratings.items(), key=lambda x: x[1], reverse=True))
+    context = {'recipes_with_ratings': recipes_with_ratings}
+    return render(request, 'tasties_app/recipes.html', context)


### PR DESCRIPTION
### Description

This PR is creating the recipes menu template. This template is meant to be the main page of the application after successful authentication.
It's taking all the recipe objects from the database, sorting them by rating value, and presenting them.

Close #74 

### What's new

- HTML and CSS files of the template
- View method was added to the `views.py` file
- A route was added to the `url.py` file
- A test file

### What it looks like

Assuming that there are valid recipe objects in the database:

![recipes](https://user-images.githubusercontent.com/85102059/210320436-e9db8845-495d-4ba6-ab7c-4fba8527f85a.png)
