### PR TITLE
Defining the recipes page as default

### DIFF
--- a/tasties/urls.py
+++ b/tasties/urls.py
@@ -20,9 +20,8 @@ from tasties_app import views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('', views.index, name="index"),
     path('base/', views.base, name="base"),
-    path('recipes/', views.recipes, name="recipes"),
+    path('', views.recipes, name="recipes"),
     path('login/', views.login_user, name="login"),
     path('register/', views.register, name="register"),
     path('logout/', views.logout_user, name="logout")

--- a/tasties_app/templates/tasties_app/base.html
+++ b/tasties_app/templates/tasties_app/base.html
@@ -33,7 +33,7 @@
     <nav class="navbar navbar-light bg-light">
 
       <!-- Logo -->
-      <a class="navbar-brand" id="logo" href="{% url 'index' %}">
+      <a class="navbar-brand" id="logo" href="{% url 'recipes' %}">
         <img
           src="{% static 'images/logo.png' %}"
           class="d-inline-block align-top"

--- a/tasties_app/tests/conftest.py
+++ b/tasties_app/tests/conftest.py
@@ -2,6 +2,7 @@ import pytest
 from django.contrib.auth.models import User
 from django.utils import timezone
 from tasties_app.models import Category, Ingredient, Rating, Recipe, Comment
+from authConstants import VALID_USER, VALID_PASSWORD, VALID_EMAIL
 
 
 @pytest.fixture
@@ -176,3 +177,9 @@ def recipe():
     recipe1.categories.add(category1)
     recipe1.save()
     return recipe1
+
+
+@pytest.fixture
+def signed_up_credentials():
+    user = User.objects.create_user(username=VALID_USER, email=VALID_EMAIL, password=VALID_PASSWORD)
+    user.save()

--- a/tasties_app/tests/test_authentication.py
+++ b/tasties_app/tests/test_authentication.py
@@ -1,5 +1,4 @@
 import pytest
-from django.contrib.auth.models import User
 from pytest_django.asserts import assertTemplateUsed
 from authConstants import (
     VALID_EMAIL, VALID_PASSWORD, VALID_USER, INVALID_EMAIL, INVALID_PASSWORD_MISMATCH, LOGIN_PATH, REGISTER_PATH,
@@ -9,11 +8,6 @@ from authConstants import (
 
 @pytest.mark.django_db
 class TestViews:
-    @pytest.fixture
-    def signed_up_credentials(self):
-        user = User.objects.create_user(username=VALID_USER, email=VALID_EMAIL, password=VALID_PASSWORD)
-        user.save()
-
     def test_login_loaded(self, client):
         response = client.get('/login/')
         assert response.status_code == 200

--- a/tasties_app/tests/test_recipes_view.py
+++ b/tasties_app/tests/test_recipes_view.py
@@ -1,10 +1,13 @@
 import pytest
-from pytest_django.asserts import assertTemplateUsed
+from authConstants import VALID_USER, VALID_PASSWORD
 
 
 @pytest.mark.django_db
 class TestRecipesView:
-    def test_recipes_view(self, client):
-        response = client.get('/recipes/')
-        assert response.status_code == 200
-        assertTemplateUsed(response, 'tasties_app/recipes.html')
+    def test_recipes_view(self, client, signed_up_credentials):
+        response = client.get('/')
+        assert response.status_code == 302
+        assert response.url == '/login/?next=/'
+        response = client.post('/login/', data={'username': VALID_USER, 'password': VALID_PASSWORD})
+        assert response.status_code == 302
+        assert response.url == '/'

--- a/tasties_app/views.py
+++ b/tasties_app/views.py
@@ -8,15 +8,11 @@ from .forms import CreateUserForm
 from django.contrib import messages
 
 
-@login_required(login_url='login')
-def index(request):
-    return render(request, 'tasties_app/index.html',)
-
-
 def base(request):
     return render(request, 'tasties_app/base.html',)
 
 
+@login_required(login_url='login')
 def recipes(request):
     recipes_list = Recipe.objects.all()
     recipes_with_ratings = {}
@@ -50,7 +46,7 @@ def logout_user(request):
 
 def register(request):
     if request.user.is_authenticated:
-        return redirect('index')
+        return redirect('recipes')
 
     form = CreateUserForm()
     if request.method == 'POST':


### PR DESCRIPTION
### Description

This PR is changing the default route to the recipes page, and it will be valid only after successful login.
Close #79 

### What's new

- Removed the `index` template entirely
- Changes the route of `recipes` to `/`
- Updated the `test_recipes_view` to check the login requirement for an unauthorized user, then check redirection to the main page after a successful login
- Moved a fixture to the `conftest` file