### PR TITLE
Fixed error messages bug in registration form

### DIFF
--- a/tasties_app/templates/tasties_app/register.html
+++ b/tasties_app/templates/tasties_app/register.html
@@ -53,7 +53,7 @@
                 {{form.password2}}
               </div>
                 {% for message in messages %}
-                    <p id="messages">{{message}}</p>
+                    {{message}}
                 {% endfor %}
               <div class="d-flex justify-content-center mt-3 login_container">
                 <input

--- a/tasties_app/views.py
+++ b/tasties_app/views.py
@@ -57,7 +57,8 @@ def register(request):
             messages.success(request, 'Account was created for ' + username)
             return redirect('login')
         else:
-            messages.error(request, form.error_messages)
+            for error_message in form.errors.values():
+                messages.error(request, error_message)
 
     context = {'form': form}
     return render(request, 'tasties_app/register.html', context)


### PR DESCRIPTION
### Description

This PR fixes a bug we had on the registration form.
When entering an invalid password, for any reason (too common, too short, not strong enough, etc...), the error message that was shown was 'password mismatch'.
Now it will show the correct messages

Close #96 

### Before

![before](https://user-images.githubusercontent.com/85102059/211774818-6cf04be7-73cf-4343-a894-bdc73fefa052.png)

### After

![after2](https://user-images.githubusercontent.com/85102059/211858734-23f2101a-0b26-4373-bc20-315878be4a41.png)
