### PR TITLE
Created recipe editing functionality

### DIFF
--- a/tasties/urls.py
+++ b/tasties/urls.py
@@ -28,7 +28,8 @@ urlpatterns = [
     path('register/', views.register, name="register"),
     path('logout/', views.logout_user, name="logout"),
     path('view_recipe/<int:recipe_id>/', views.view_recipe, name="view_recipe"),
-    path('create_recipe/', views.create_recipe, name="create_recipe")
+    path('create_recipe/', views.create_recipe, name="create_recipe"),
+    path('edit_recipe/<int:recipe_id>/', views.edit_recipe, name="edit_recipe"),
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/tasties_app/static/css/view_recipe.css
+++ b/tasties_app/static/css/view_recipe.css
@@ -11,6 +11,21 @@
     font-size: 14px;
 }
 
+.recipe-title{
+    display: flex;
+    justify-content: space-between;
+}
+
+.btn-warning{
+    color: #924709;
+}
+
+.btn-warning:hover{
+    background-color: #fff;
+    color: #924709;
+    border: 1px solid #924709;
+}
+
 .categories .btn{
     background-color: #20bd92;
     color: #fff;

--- a/tasties_app/templates/tasties_app/edit_recipe.html
+++ b/tasties_app/templates/tasties_app/edit_recipe.html
@@ -1,0 +1,2 @@
+{% extends 'tasties_app/create_recipe.html' %}
+{% block crud-action %}<h1>Edit Recipe</h1>{% endblock %}

--- a/tasties_app/templates/tasties_app/view_recipe.html
+++ b/tasties_app/templates/tasties_app/view_recipe.html
@@ -7,7 +7,10 @@
 {% block content %}
     <div class="recipe-body">
         <div class="recipe-header">
-            <h1>{{ recipe.title }}</h1>
+            <div class="recipe-title text-center">
+                <h1>{{ recipe.title }}</h1>
+                {% if can_edit %} <span class="align-middle"><a href="/edit_recipe/{{ recipe.id }}/" class="btn btn-warning">Edit Recipe</a></span>{% endif %}
+            </div>
             <h2>{{ recipe.description }}</h2>
             <div class="recipe-header-info">
                 <span class="author-name">By @{{ recipe.author_id }}</span>

--- a/tasties_app/tests/test_edit_recipe.py
+++ b/tasties_app/tests/test_edit_recipe.py
@@ -1,0 +1,107 @@
+import pytest
+from authConstants import VALID_USER, VALID_PASSWORD
+from tasties_app.models import Recipe
+from django.core.exceptions import ObjectDoesNotExist
+from pytest_django.asserts import assertTemplateUsed
+
+
+@pytest.mark.django_db
+class TestEditRecipe:
+    def test_require_login(self, client, recipe_test, signed_up_credentials):
+        """
+        This test verifies that a user must be logged
+        in to edit a recipe. If a user is not logged in,
+        redirect to '/' is expected.
+
+        Args:
+            client : Django testing client
+            signed_up_credentials (fixture): creates a user
+        """
+        response = client.get("/edit_recipe/"+str(recipe_test.id)+"/")
+        assert response.status_code == 302
+        assert (
+            response.url == "/login/?next=/edit_recipe/"+str(recipe_test.id)+"/"
+        )
+        response = client.post(
+            "/login/", data={"username": VALID_USER, "password": VALID_PASSWORD}
+        )
+        assert response.status_code == 302
+        assert response.url == "/"
+
+    def test_unauthorized_access(self, client, recipe_test, signed_up_credentials, login_to_site):
+        """
+        This test verifies that a logged in user cannot edit a recipe authored
+        by a different user
+
+        Args:
+            client : Django testing client
+            recipe_test (fixture): creates a user, and a recipe owned by it
+            signed_up_credentials (fixture): creates a user
+            login_to_site (fixture): logs in user created by signed_up_credentials
+        """
+        response = client.get("/edit_recipe/"+str(recipe_test.id)+"/")
+        assert response.status_code == 302
+        assert (
+            response.url == "/"
+        )
+
+    def test_valid_edits(
+        self,
+        client,
+        recipe_test,
+        form_data,
+        formset_data
+    ):
+        """
+        This test verifies that valid edits to a recipe
+        using the view function edit_recipe will be saved
+
+        Args:
+            client : Django testing client
+            recipe_test (fixture): creates a user, and a recipe owned by it
+            form_data (dictionary): raw data for recipe form
+            formset_data (dictionary): raw data for ingredient formset
+        """
+        author = recipe_test.author_id
+        recipe_id = recipe_test.id
+        client.force_login(author)
+        response = client.get("/edit_recipe/"+str(recipe_id)+"/")
+        assertTemplateUsed(response, 'tasties_app/edit_recipe.html')  # assert on edit page
+
+        form_data.update(formset_data)
+        response = client.post(
+            "/edit_recipe/"+str(recipe_id)+"/", data=form_data
+        )
+
+        assert Recipe.objects.filter(title=form_data['title']).exists()
+        saved_recipe = Recipe.objects.get(title=form_data['title'])
+        assert saved_recipe.author_id == author
+        assert saved_recipe.id == recipe_id
+        assert response.status_code == 302
+        assert response.url == "/view_recipe/" + str(saved_recipe.id) + "/"
+
+    def test_no_ingredients(
+        self, client, recipe_test, form_data
+    ):
+        """
+        This tests verifies that a recipe without ingredients
+        cannot be saved.
+
+        Args:
+            client : Django testing client
+            signed_up_credentials (fixture): creates a user
+            login_to_site (fixture): logs in user created by signed_up_credentials
+            form_data (dictionary): raw data for recipe form
+        """
+        author = recipe_test.author_id
+        recipe_id = recipe_test.id
+        client.force_login(author)
+        response = client.get("/edit_recipe/"+str(recipe_id)+"/")
+        assertTemplateUsed(response, 'tasties_app/edit_recipe.html')
+
+        response = client.post(
+            "/edit_recipe/"+str(recipe_id)+"/", data=form_data
+        )
+        with pytest.raises(ObjectDoesNotExist):
+            Recipe.objects.get(title=form_data['title'])
+        assertTemplateUsed(response, 'tasties_app/create_recipe.html')


### PR DESCRIPTION
Added functionality to edit recipes, based off of [my recipe creation PR](https://github.com/redhat-beyond/tasties/pull/100).

- A user may only edit a recipe that they had created
- A user may access the edit feature for their recipe from its `view_recipe` page
- Must be merged after #100 
- Closes #106 

Recipe before editing:
![localhost_8000_view_recipe_74_](https://user-images.githubusercontent.com/116169213/212978199-bb8fae9b-b8ee-4bcc-aded-dd17e1f35524.png)

Recipe being edited:
![localhost_8000_edit_recipe_74_](https://user-images.githubusercontent.com/116169213/212978254-c135ea77-8e89-4326-a2eb-7f75ddbb9ff6.png)

Recipe after edit:
![localhost_8000_view_recipe_74_ (2)](https://user-images.githubusercontent.com/116169213/212978287-d9c1f48a-32e3-44cc-b16a-f2d4bcd4f1ab.png)
